### PR TITLE
fix: default output is to stdout now

### DIFF
--- a/yamldifftool.py
+++ b/yamldifftool.py
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     parser.add_argument("user_customized_values", metavar="customized.yaml", type=str, help="Customized values.yaml")
     parser.add_argument("-o", "--output", default=None, type=str,
                         help="Write to filename. If not specified, output is written to stdout.")
-    parser.add_argument("-s", "--strict", default=False, action=argparse.BooleanOptionalAction,
+    parser.add_argument("-s", "--strict", default=False, action=argparse.BooleanOptionalAction, type=bool,
                         help="strict mode will drop all options not in default values.yaml.")
     args = parser.parse_args()
 

--- a/yamldifftool.py
+++ b/yamldifftool.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import yaml
 import argparse
+import sys
 
 
 def traverse_and_set(user_provided, root_diff, path):
@@ -35,9 +36,9 @@ if __name__ == "__main__":
     parser.add_argument("default_values", metavar="default_values.yaml", type=str,
                         help="Base values.yaml for the helm chart version you're using")
     parser.add_argument("user_customized_values", metavar="customized.yaml", type=str, help="Customized values.yaml")
-    parser.add_argument("-o", "--output", default="output", type=str,
-                        help="Write to filename. Otherwise default is output")
-    parser.add_argument("-s", "--strict", default=False, action=argparse.BooleanOptionalAction, type=bool,
+    parser.add_argument("-o", "--output", default=None, type=str,
+                        help="Write to filename. If not specified, output is written to stdout.")
+    parser.add_argument("-s", "--strict", default=False, action=argparse.BooleanOptionalAction,
                         help="strict mode will drop all options not in default values.yaml.")
     args = parser.parse_args()
 
@@ -49,5 +50,8 @@ if __name__ == "__main__":
 
     filter_defaults(default_v, overwritten_v, root_diff, path, args.strict)
 
-    with open(args.output, 'w') as outfile:
-        yaml.dump(root_diff, outfile, sort_keys=False)
+    if args.output:
+        with open(args.output, 'w') as outfile:
+            yaml.dump(root_diff, outfile, sort_keys=False)
+    else:
+        yaml.dump(root_diff, sys.stdout, sort_keys=False)


### PR DESCRIPTION
### Which problem does the PR fix?

This PR addresses an issue with the project where the user had to specify a file to put the output in. Now, if the user does not provide the --output argument, the output will go to stdout instead.

<!-- Which GitHub issues are related to or fixed by this PR, if any? -->

This is related to #1 
