### PR TITLE
Helm integration

### DIFF
--- a/yamldifftool.py
+++ b/yamldifftool.py
@@ -41,10 +41,10 @@ if __name__ == "__main__":
                         help="Write to filename. If not specified, output is written to stdout.")
     parser.add_argument("-s", "--strict", default=False, action=argparse.BooleanOptionalAction, type=bool,
                         help="strict mode will drop all options not in default values.yaml.")
-    parser.add_argument("--default_values", metavar="default_values.yaml", type=str,
+    parser.add_argument("-d", "--default_values", metavar="default_values.yaml", type=str,
                         help="Base values.yaml for the helm chart version you're using")
-    parser.add_argument("--chart", type=str, help="Helm chart name")
-    parser.add_argument("--version", type=str, help="Helm chart version")
+    parser.add_argument("-c", "--chart", type=str, help="Helm chart name")
+    parser.add_argument("-v", "--version", type=str, help="Helm chart version")
     args = parser.parse_args()
 
     if args.default_values:


### PR DESCRIPTION
closes #11 

This PR adds `--chart` and `--version` to do an equivalent of 
```
helm show helm_chart --version version 
```
and feed that into the program.

I'm unsure if I want to merge this, since it changes the CLI input parameters, and users could pretty easily run `helm show ...` themselves.